### PR TITLE
Fix duplicate listing of unranked players

### DIFF
--- a/l.py
+++ b/l.py
@@ -125,13 +125,20 @@ def rank_players(league_entries):
 # Format ranked stats for display
 def format_ranked_stats(ranked_players, queue_type):
     formatted = f"**{queue_type}**\n"
+
+    # Track which accounts have already been listed
+    used_accounts = {p['summonerName'] for p in ranked_players if p}
+
     for player in ranked_players:
         if player:
             formatted += f"{player['summonerName']}: **{player['tier']} {player['rank']} {player['leaguePoints']}LP**\n"
         else:
-            # Find the corresponding account for this unranked player
-            unranked_player = next((f"{name}#{tag}" for name, tag in ACCOUNTS if f"{name}#{tag}" not in [p['summonerName'] for p in ranked_players if p]), "Unknown Player")
+            # Find the next account that hasn't been used yet
+            remaining = [f"{name}#{tag}" for name, tag in ACCOUNTS if f"{name}#{tag}" not in used_accounts]
+            unranked_player = remaining[0] if remaining else "Unknown Player"
+            used_accounts.add(unranked_player)
             formatted += f"{unranked_player}: **Unranked**\n"
+
     return formatted.strip()
 
 async def update_ranked_stats(channel):


### PR DESCRIPTION
## Summary
- fix bug where multiple unranked accounts were printed with the same name

## Testing
- `python -m py_compile l.py`


------
https://chatgpt.com/codex/tasks/task_b_688279aa0c6c832eaa93a04e65665541